### PR TITLE
#37 createRootのimportをReact18のやり方に修正

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client.js';
+import { createRoot } from 'react-dom/client';
 import App from './App.js';
 import './index.css';
 
-ReactDOM.createRoot(document.querySelector('#root')!).render(
+createRoot(document.querySelector('#root')!).render(
     <React.StrictMode>
         <App />
     </React.StrictMode>


### PR DESCRIPTION
 createRootのimport方法がReact18に対応しておらずビルドが失敗するようになっていたので修正。

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis を参考に修正しました